### PR TITLE
deleted check for if name = "content"

### DIFF
--- a/packages/jade-compiler/lib/transpilers.js
+++ b/packages/jade-compiler/lib/transpilers.js
@@ -104,9 +104,7 @@ _.extend(FileCompiler.prototype, {
         throwError('Templates must only have a "name" attribute', node);
 
       var name = node.attrs[0].val.slice(1, -1);
-
-      if (name === "content")
-        throwError('Template can\'t be named "content"', node);
+      
       if (_.has(self.templates, name))
         throwError('Template "' + name + '" is set twice', node);
 


### PR DESCRIPTION
Deleted the if statement that checks if the template is named 'content'. This is thought to be leftover from Spacebars.
